### PR TITLE
feat: add langgraph orchestrator

### DIFF
--- a/examples/lovable_mini/graph.json
+++ b/examples/lovable_mini/graph.json
@@ -1,0 +1,20 @@
+{
+  "start": "router",
+  "limits": { "global_steps": 30, "global_seconds": 240 },
+  "human_approval_after": ["coder"],
+  "agents": {
+    "router": { "type": "rule", "max_steps": 1 },
+    "planner":  { "allow_tools": ["browser.search","browser.open"], "max_steps": 6 },
+    "ux":       { "allow_tools": [], "max_steps": 4 },
+    "coder":    { "allow_tools": ["fs.mkdir","fs.write","fs.read"], "max_steps": 8 },
+    "verifier": { "allow_tools": ["fs.read"], "max_steps": 4 }
+  },
+  "edges": [
+    ["router","planner"],
+    ["planner","ux"],
+    ["ux","coder"],
+    ["coder","verifier"],
+    ["verifier","END"],
+    ["verifier","coder"]
+  ]
+}

--- a/examples/lovable_mini/run.py
+++ b/examples/lovable_mini/run.py
@@ -1,0 +1,18 @@
+import asyncio, json, sys
+from mcp_use.client import MCPClient
+from mcp_use.orchestrator.orchestrator import MCPOrchestrator
+from mcp_use.orchestrator.config import load_graph_config
+
+async def main():
+    prompt = sys.argv[1] if len(sys.argv) > 1 else \
+        "Generate a simple landing page for 'Mars Technosoft' (hero, features, contact)."
+
+    client = MCPClient.from_config_file("examples/lovable_mini/servers.json")
+    cfg = load_graph_config("examples/lovable_mini/graph.json")
+    orch = MCPOrchestrator(client, cfg)
+
+    async for chunk in orch.astream(prompt):
+        print(chunk, end="", flush=True)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/lovable_mini/servers.json
+++ b/examples/lovable_mini/servers.json
@@ -1,0 +1,7 @@
+{
+  "llm": { "provider": "openai", "model": "gpt-4o-mini" },
+  "servers": [
+    { "name": "browser", "type": "stdio", "cmd": "npx", "args": ["@mcp/cli", "playwright"] },
+    { "name": "fs", "type": "stdio", "cmd": "npx", "args": ["@mcp/cli", "filesystem", "--root=./out"] }
+  ]
+}

--- a/mcp_use/orchestrator/__init__.py
+++ b/mcp_use/orchestrator/__init__.py
@@ -1,0 +1,4 @@
+from .config import AgentConfig, GraphConfig
+from .orchestrator import MCPOrchestrator
+
+__all__ = ["MCPOrchestrator", "GraphConfig", "AgentConfig"]

--- a/mcp_use/orchestrator/agent_node.py
+++ b/mcp_use/orchestrator/agent_node.py
@@ -1,0 +1,48 @@
+"""LangGraph node wrapper around :class:`MCPAgent`."""
+from __future__ import annotations
+
+from typing import Any
+
+try:  # pragma: no cover - optional
+    from langgraph.types import Command
+except Exception:  # pragma: no cover - fallback
+    from dataclasses import dataclass
+
+    @dataclass
+    class Command:  # type: ignore
+        goto: str | None = None
+        update: dict | None = None
+
+from .policy import Budgets, ToolPolicy, enforce_before_agent_step
+from .state import RunState, get_ns
+
+
+class AgentNode:
+    """Wrap an :class:`MCPAgent` for graph execution."""
+
+    def __init__(self, name: str, agent: Any, policy: ToolPolicy | None = None, budgets: Budgets | None = None):
+        self.name = name
+        self.agent = agent
+        self.policy = policy
+        self.budgets = budgets
+
+    async def __call__(self, state: RunState) -> Command:
+        prompt = state.get("next_prompt") or ""
+        enforce_before_agent_step(state, self.name, self.policy, self.budgets)
+
+        result = await self.agent.run(prompt)  # type: ignore[no-untyped-call]
+
+        agent_ns = get_ns(state, self.name)
+        agent_ns["last"] = result
+        agent_ns["steps"] = agent_ns.get("steps", 0) + 1
+        state["artifacts"][f"{self.name}_output"] = result
+        state["messages"].append(result)
+        state["budget"]["steps"] += 1
+
+        # enforce tool policy after step
+        if self.policy and self.policy.allowed_tools:
+            for tool in getattr(self.agent, "tools_used_names", []):
+                if tool not in self.policy.allowed_tools:
+                    raise RuntimeError(f"tool {tool} not allowed for {self.name}")
+
+        return Command(update={"next_prompt": result})

--- a/mcp_use/orchestrator/builder.py
+++ b/mcp_use/orchestrator/builder.py
@@ -1,0 +1,121 @@
+"""Utilities to build agents and compile graphs."""
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable
+from typing import Any
+
+try:  # pragma: no cover - optional
+    from langgraph.constants import END, START
+    from langgraph.graph import StateGraph
+    from langgraph.types import Command
+except Exception:  # pragma: no cover - fallback
+    from dataclasses import dataclass
+
+    START = "START"
+    END = "END"
+
+    @dataclass
+    class Command:  # type: ignore
+        goto: str | None = None
+        update: dict | None = None
+
+    class StateGraph:
+        def __init__(self, _state):
+            self.nodes: dict[str, Callable[[Any], Any]] = {}
+            self.edges: defaultdict[str, list[str]] = defaultdict(list)
+
+        def add_node(self, name: str, fn: Callable[[Any], Any]) -> None:
+            self.nodes[name] = fn
+
+        def add_edge(self, src: str, dst: str) -> None:
+            self.edges[src].append(dst)
+
+        def compile(self) -> CompiledGraph:
+            return CompiledGraph(self.nodes, self.edges)
+
+    class CompiledGraph:
+        def __init__(self, nodes, edges):
+            self.nodes = nodes
+            self.edges = edges
+
+        async def astep(self, state, node: str):
+            fn = self.nodes[node]
+            result = await fn(state)
+            if isinstance(result, Command):
+                if result.update:
+                    state.update(result.update)
+                goto = result.goto
+            else:
+                goto = None
+            if goto is None:
+                goto = self.edges.get(node, [END])[0]
+            return state, goto
+
+    StateGraphCompiled = CompiledGraph
+
+from mcp_use.agents import MCPAgent
+
+from .agent_node import AgentNode
+from .config import GraphConfig
+from .policy import Budgets, ToolPolicy
+from .router import RuleRouterNode
+from .state import RunState
+
+
+def _load_llm(client, model_override: str | None = None):
+    cfg = getattr(client, "config", {}).get("llm", {})
+    model = model_override or cfg.get("model")
+    provider = cfg.get("provider")
+    if provider == "openai" and model:
+        try:  # pragma: no cover - optional
+            from langchain_openai import ChatOpenAI
+
+            return ChatOpenAI(model=model)
+        except Exception:  # pragma: no cover - fallback
+            return None
+    return None
+
+
+def build_agents(client, cfg: GraphConfig) -> dict[str, MCPAgent]:
+    agents: dict[str, MCPAgent] = {}
+    for name, acfg in cfg.agents.items():
+        if acfg.type == "rule":
+            continue
+        llm = _load_llm(client, acfg.model)
+        agent = MCPAgent(
+            llm=llm,  # type: ignore[arg-type]
+            client=client,
+            max_steps=acfg.max_steps,
+            use_server_manager=True,
+        )
+        agents[name] = agent
+    return agents
+
+
+def compile_graph(client, cfg: GraphConfig):
+    agents = build_agents(client, cfg)
+    graph = StateGraph(RunState)
+
+    # Router
+    router_cfg = cfg.agents.get(cfg.start)
+    if router_cfg and router_cfg.type == "rule":
+        router = RuleRouterNode(cfg.edge_map)
+        graph.add_node(cfg.start, router)
+    else:
+        raise ValueError("start node must be a router")
+
+    # Agent nodes
+    for name, agent in agents.items():
+        policy = ToolPolicy(acfg.allow_tools if (acfg := cfg.agents[name]).allow_tools else [])
+        budgets = Budgets(max_steps=acfg.max_steps)
+        graph.add_node(name, AgentNode(name, agent, policy, budgets))
+
+    # Edges
+    graph.add_edge(START, cfg.start)
+    for src, dst in cfg.edges:
+        graph.add_edge(src, dst)
+    graph.add_edge(END, END)
+
+    app = graph.compile()
+    return app

--- a/mcp_use/orchestrator/checkpointer.py
+++ b/mcp_use/orchestrator/checkpointer.py
@@ -1,0 +1,27 @@
+"""Checkpoint persistence for orchestrator runs."""
+from __future__ import annotations
+
+import json
+import os
+
+from .state import RunState
+
+
+class JsonCheckpointer:
+    """Store run state to JSON files."""
+
+    def __init__(self, base_path: str = ".mcp_use_runs") -> None:
+        self.base_path = base_path
+
+    def _path(self, run_id: str) -> str:
+        return os.path.join(self.base_path, f"{run_id}.json")
+
+    def save(self, run_id: str, state: RunState, meta: dict) -> None:
+        os.makedirs(self.base_path, exist_ok=True)
+        with open(self._path(run_id), "w", encoding="utf-8") as fh:
+            json.dump({"state": state, "meta": meta}, fh)
+
+    def load(self, run_id: str) -> tuple[RunState, dict]:
+        with open(self._path(run_id), encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data["state"], data.get("meta", {})

--- a/mcp_use/orchestrator/cli.py
+++ b/mcp_use/orchestrator/cli.py
@@ -1,0 +1,26 @@
+"""Simple CLI entrypoint for the orchestrator demo."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from mcp_use.client import MCPClient
+
+from .config import load_graph_config
+from .events import ConsoleEventBus
+from .orchestrator import MCPOrchestrator
+
+
+async def main(prompt: str) -> None:
+    client = MCPClient.from_config_file("examples/lovable_mini/servers.json")
+    cfg = load_graph_config("examples/lovable_mini/graph.json")
+    orch = MCPOrchestrator(client, cfg, event_bus=ConsoleEventBus())
+    async for chunk in orch.astream(prompt):
+        print(chunk, end="", flush=True)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI utility
+    parser = argparse.ArgumentParser()
+    parser.add_argument("prompt", nargs="?", default="Hello")
+    args = parser.parse_args()
+    asyncio.run(main(args.prompt))

--- a/mcp_use/orchestrator/config.py
+++ b/mcp_use/orchestrator/config.py
@@ -1,0 +1,43 @@
+"""Configuration models for the orchestrator."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+
+@dataclass
+class AgentConfig:
+    type: str = "agent"
+    allow_tools: list[str] | None = None
+    max_steps: int = 0
+    model: str | None = None
+
+
+@dataclass
+class GraphConfig:
+    start: str
+    limits: dict[str, int] = field(default_factory=dict)
+    human_approval_after: list[str] = field(default_factory=list)
+    agents: dict[str, AgentConfig] = field(default_factory=dict)
+    edges: list[tuple[str, str]] = field(default_factory=list)
+
+    @property
+    def edge_map(self) -> dict[str, list[str]]:
+        m: dict[str, list[str]] = {}
+        for src, dst in self.edges:
+            m.setdefault(src, []).append(dst)
+        return m
+
+
+def load_graph_config(path: str) -> GraphConfig:
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    agents = {k: AgentConfig(**v) for k, v in data.get("agents", {}).items()}
+    edges = [tuple(e) for e in data.get("edges", [])]
+    return GraphConfig(
+        start=data.get("start", ""),
+        limits=data.get("limits", {}),
+        human_approval_after=data.get("human_approval_after", []),
+        agents=agents,
+        edges=edges,
+    )

--- a/mcp_use/orchestrator/events.py
+++ b/mcp_use/orchestrator/events.py
@@ -1,0 +1,33 @@
+"""Lightweight event bus for orchestration."""
+from __future__ import annotations
+
+from .state import RunState
+
+
+class EventBus:
+    """Base event bus with no-op handlers."""
+
+    def on_step_start(self, name: str, state: RunState) -> None:  # pragma: no cover - default
+        pass
+
+    def on_step_end(self, name: str, state: RunState) -> None:  # pragma: no cover - default
+        pass
+
+    def on_tool_call(self, agent: str, tool_name: str, args: dict | None = None) -> None:  # pragma: no cover - default
+        pass
+
+    def on_handoff(self, src: str, dst: str) -> None:  # pragma: no cover - default
+        pass
+
+    def on_error(self, name: str, exc: Exception) -> None:  # pragma: no cover - default
+        pass
+
+
+class ConsoleEventBus(EventBus):
+    """Simple console logger implementation."""
+
+    def on_step_start(self, name: str, state: RunState) -> None:  # pragma: no cover - logging
+        print(f"--- switching to {name} ---")
+
+    def on_handoff(self, src: str, dst: str) -> None:  # pragma: no cover - logging
+        print(f"handoff: {src} -> {dst}")

--- a/mcp_use/orchestrator/orchestrator.py
+++ b/mcp_use/orchestrator/orchestrator.py
@@ -1,0 +1,84 @@
+"""High level orchestration entrypoint."""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+try:  # pragma: no cover - optional
+    from langgraph.constants import END
+except Exception:  # pragma: no cover - fallback
+    END = "END"
+
+from .builder import compile_graph
+from .checkpointer import JsonCheckpointer
+from .config import GraphConfig
+from .events import EventBus
+from .state import RunState, init_state
+
+
+class MCPOrchestrator:
+    """Coordinate multiple :class:`MCPAgent` instances via a graph."""
+
+    def __init__(
+        self,
+        client,
+        graph_cfg: dict | GraphConfig,
+        *,
+        checkpointer: JsonCheckpointer | None = None,
+        event_bus: EventBus | None = None,
+    ) -> None:
+        self.client = client
+        self.cfg = graph_cfg if isinstance(graph_cfg, GraphConfig) else GraphConfig(**graph_cfg)
+        self.checkpointer = checkpointer
+        self.event_bus = event_bus or EventBus()
+        self.app = compile_graph(client, self.cfg)
+        self._run_id: str | None = None
+
+    async def run(self, prompt: str) -> RunState:
+        state = init_state(prompt, self.cfg.limits.get("global_steps", 50))
+        self._run_id = state["run_id"]
+        node = self.cfg.start
+        while node != END:
+            self.event_bus.on_step_start(node, state)
+            state, next_node = await self.app.astep(state, node)
+            state["last_hop"] = node
+            self.event_bus.on_step_end(node, state)
+            if node in self.cfg.human_approval_after and next_node != END:
+                if self.checkpointer:
+                    self.checkpointer.save(self._run_id, state, {"next_node": next_node})
+                break
+            node = next_node
+        if node == END and self.checkpointer:
+            self.checkpointer.save(self._run_id, state, {"next_node": END})
+        return state
+
+    async def astream(self, prompt: str) -> AsyncIterator[str | dict]:
+        state = init_state(prompt, self.cfg.limits.get("global_steps", 50))
+        self._run_id = state["run_id"]
+        node = self.cfg.start
+        while node != END:
+            self.event_bus.on_step_start(node, state)
+            state, next_node = await self.app.astep(state, node)
+            state["last_hop"] = node
+            yield state.get("ns", {}).get(node, {}).get("last", "")
+            self.event_bus.on_step_end(node, state)
+            if node in self.cfg.human_approval_after and next_node != END:
+                if self.checkpointer:
+                    self.checkpointer.save(self._run_id, state, {"next_node": next_node})
+                break
+            node = next_node
+        if node == END and self.checkpointer:
+            self.checkpointer.save(self._run_id, state, {"next_node": END})
+
+    async def resume(self, run_id: str) -> RunState:
+        if not self.checkpointer:
+            raise RuntimeError("no checkpointer configured")
+        state, meta = self.checkpointer.load(run_id)
+        node = meta.get("next_node", self.cfg.start)
+        while node != END:
+            self.event_bus.on_step_start(node, state)
+            state, next_node = await self.app.astep(state, node)
+            state["last_hop"] = node
+            self.event_bus.on_step_end(node, state)
+            node = next_node
+        self.checkpointer.save(run_id, state, {"next_node": END})
+        return state

--- a/mcp_use/orchestrator/policy.py
+++ b/mcp_use/orchestrator/policy.py
@@ -1,0 +1,37 @@
+"""Policy and budget utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .state import RunState, get_ns
+
+
+@dataclass
+class ToolPolicy:
+    """Simple policy describing allowed tools for an agent."""
+
+    allowed_tools: list[str]
+    disallowed_tools: list[str] | None = None
+
+
+@dataclass
+class Budgets:
+    max_steps: int | None = None
+    max_tokens: int | None = None
+    max_seconds: int | None = None
+
+
+def enforce_before_agent_step(
+    state: RunState, agent_name: str, policy: ToolPolicy | None, budgets: Budgets | None
+) -> None:
+    """Verify budget limits before executing an agent step."""
+    steps = state["budget"]["steps"]
+    max_steps = state["budget"].get("max_steps")
+    if max_steps is not None and steps >= max_steps:
+        raise RuntimeError("global step budget exceeded")
+
+    if budgets and budgets.max_steps is not None:
+        agent_ns = get_ns(state, agent_name)
+        taken = agent_ns.get("steps", 0)
+        if taken >= budgets.max_steps:
+            raise RuntimeError(f"{agent_name} exceeded step budget")

--- a/mcp_use/orchestrator/router.py
+++ b/mcp_use/orchestrator/router.py
@@ -1,0 +1,46 @@
+"""Routing nodes."""
+from __future__ import annotations
+
+try:  # pragma: no cover - optional
+    from langgraph.types import Command
+except Exception:  # pragma: no cover - fallback
+    from dataclasses import dataclass
+
+    @dataclass
+    class Command:  # type: ignore
+        goto: str | None = None
+        update: dict | None = None
+
+from .state import RunState
+
+
+class RuleRouterNode:
+    """Deterministic router following edges and ``last_hop``."""
+
+    def __init__(self, edges: dict[str, list[str]]) -> None:
+        self.edges = edges
+
+    async def __call__(self, state: RunState) -> Command:
+        last = state.get("last_hop") or "router"
+        next_nodes = self.edges.get(last, [])
+        goto = next_nodes[0] if next_nodes else "END"
+        return Command(goto=goto)
+
+
+class SupervisorRouterNode:
+    """Router that asks an MCPAgent which node to run next."""
+
+    def __init__(self, agent) -> None:
+        self.agent = agent
+
+    async def __call__(self, state: RunState) -> Command:  # pragma: no cover - simple
+        prompt = state.get("next_prompt") or ""
+        resp = await self.agent.run(prompt)
+        try:
+            import json
+
+            data = json.loads(resp)
+            goto = data.get("next")
+        except Exception:
+            goto = None
+        return Command(goto=goto)

--- a/mcp_use/orchestrator/state.py
+++ b/mcp_use/orchestrator/state.py
@@ -1,0 +1,48 @@
+"""State helpers for the orchestrator."""
+from __future__ import annotations
+
+import uuid
+from collections.abc import MutableMapping
+from typing import Any, TypedDict
+
+
+class RunState(TypedDict, total=False):
+    """State tracked across orchestrator runs."""
+
+    messages: list[str]
+    artifacts: dict[str, str]
+    ns: dict[str, dict[str, Any]]
+    next_prompt: str | None
+    final_answer: str | None
+    budget: dict[str, int]
+    approvals: dict[str, bool]
+    last_hop: str | None
+    run_id: str
+
+
+def init_state(prompt: str, global_steps: int) -> RunState:
+    """Create an initial :class:`RunState` for a new run."""
+    return {
+        "messages": [prompt],
+        "artifacts": {},
+        "ns": {},
+        "next_prompt": prompt,
+        "final_answer": None,
+        "budget": {"steps": 0, "max_steps": global_steps},
+        "approvals": {},
+        "last_hop": None,
+        "run_id": uuid.uuid4().hex,
+    }
+
+
+def get_ns(state: MutableMapping[str, Any], name: str) -> MutableMapping[str, Any]:
+    """Return the namespace for an agent, creating it if needed."""
+    ns = state.setdefault("ns", {})  # type: ignore[assignment]
+    return ns.setdefault(name, {})
+
+
+def trim_messages(state: RunState, max_messages: int) -> None:
+    """Trim message history to the last ``max_messages`` items."""
+    msgs = state.get("messages")
+    if msgs is not None and len(msgs) > max_messages:
+        state["messages"] = msgs[-max_messages:]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "posthog>=4.8.0",
     "scarf-sdk>=0.1.0",
+    "langgraph>=0.2",
+    "typing_extensions",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_orchestrator_minimal.py
+++ b/tests/test_orchestrator_minimal.py
@@ -1,0 +1,54 @@
+import pytest
+
+from mcp_use.client import MCPClient
+from mcp_use.orchestrator import MCPOrchestrator
+from mcp_use.orchestrator.config import AgentConfig, GraphConfig
+
+
+class DummyAgent:
+    def __init__(self, *args, **kwargs):
+        self.tools_used_names = []
+
+    async def run(self, prompt: str) -> str:
+        self.tools_used_names.append("dummy")
+        return f"{prompt}-done"
+
+
+def make_client() -> MCPClient:
+    return MCPClient(config={"servers": [], "llm": {}})
+
+
+@pytest.mark.asyncio
+async def test_minimal_flow(monkeypatch):
+    monkeypatch.setattr("mcp_use.orchestrator.builder.MCPAgent", DummyAgent)
+
+    cfg = GraphConfig(
+        start="router",
+        limits={"global_steps": 5},
+        human_approval_after=[],
+        agents={
+            "router": AgentConfig(type="rule", max_steps=1),
+            "A": AgentConfig(allow_tools=["dummy"], max_steps=1),
+            "B": AgentConfig(allow_tools=["dummy"], max_steps=1),
+        },
+        edges=[("router", "A"), ("A", "B"), ("B", "END")],
+    )
+    orch = MCPOrchestrator(make_client(), cfg)
+    state = await orch.run("hi")
+    assert state["artifacts"]["A_output"] == "hi-done"
+    assert state["artifacts"]["B_output"] == "hi-done"
+    assert state["last_hop"] == "B"
+
+    cfg_bad = GraphConfig(
+        start="router",
+        limits={"global_steps": 5},
+        human_approval_after=[],
+        agents={
+            "router": AgentConfig(type="rule", max_steps=1),
+            "A": AgentConfig(allow_tools=[], max_steps=1),
+        },
+        edges=[("router", "A"), ("A", "END")],
+    )
+    orch_bad = MCPOrchestrator(make_client(), cfg_bad)
+    with pytest.raises(RuntimeError):
+        await orch_bad.run("hi")

--- a/tests/test_orchestrator_resume.py
+++ b/tests/test_orchestrator_resume.py
@@ -1,0 +1,45 @@
+import pytest
+
+from mcp_use.client import MCPClient
+from mcp_use.orchestrator import MCPOrchestrator
+from mcp_use.orchestrator.checkpointer import JsonCheckpointer
+from mcp_use.orchestrator.config import AgentConfig, GraphConfig
+
+
+class DummyAgent:
+    def __init__(self, *args, **kwargs):
+        self.tools_used_names = []
+
+    async def run(self, prompt: str) -> str:
+        self.tools_used_names.append("dummy")
+        return f"{prompt}-done"
+
+
+def make_client() -> MCPClient:
+    return MCPClient(config={"servers": [], "llm": {}})
+
+
+@pytest.mark.asyncio
+async def test_resume(monkeypatch, tmp_path):
+    monkeypatch.setattr("mcp_use.orchestrator.builder.MCPAgent", DummyAgent)
+    checkpointer = JsonCheckpointer(base_path=tmp_path.as_posix())
+
+    cfg = GraphConfig(
+        start="router",
+        limits={"global_steps": 5},
+        human_approval_after=["coder"],
+        agents={
+            "router": AgentConfig(type="rule", max_steps=1),
+            "coder": AgentConfig(allow_tools=["dummy"], max_steps=1),
+            "verifier": AgentConfig(allow_tools=["dummy"], max_steps=1),
+        },
+        edges=[("router", "coder"), ("coder", "verifier"), ("verifier", "END")],
+    )
+    orch = MCPOrchestrator(make_client(), cfg, checkpointer=checkpointer)
+    state = await orch.run("hi")
+    run_id = orch._run_id  # type: ignore[attr-defined]
+    assert state["last_hop"] == "coder"
+    assert "verifier_output" not in state["artifacts"]
+
+    resumed = await orch.resume(run_id)
+    assert resumed["artifacts"]["verifier_output"] == "hi-done"


### PR DESCRIPTION
## Summary
- add lightweight orchestrator built around LangGraph for composing MCP agents
- support JSON graph configs, checkpointing, and basic routing
- include Lovable Mini demo and async tests

## Testing
- `ruff check mcp_use/orchestrator tests/test_orchestrator_minimal.py tests/test_orchestrator_resume.py`
- `pytest tests/test_orchestrator_minimal.py tests/test_orchestrator_resume.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68a10a5776c883279418e31018564f72